### PR TITLE
Update installation link for krohnkite

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Follow the instructions, then apply the new theme from the system settings, eith
 5. Now, applying the wallpaper will imitate a progressive blur on the panel.
 
 ### Dynamic Tiling
-1. Install: https://github.com/esjeon/krohnkite
+1. Install: https://github.com/anametologin/krohnkite
 2. Enable it from System Settings -> Window Management -> KWin Scripts
 
 ### Window Blurring with Better Blur

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Follow the instructions, then apply the new theme from the system settings, eith
 5. Now, applying the wallpaper will imitate a progressive blur on the panel.
 
 ### Dynamic Tiling
-1. Install: https://github.com/anametologin/krohnkite
+1. Install: https://codeberg.org/anametologin/Krohnkite
 2. Enable it from System Settings -> Window Management -> KWin Scripts
 
 ### Window Blurring with Better Blur


### PR DESCRIPTION
Hi, I noticed that the README suggests installing Krohnkite from [esjeon/krohnkite](https://github.com/esjeon/krohnkite).
There’s a fork [anametologin/Krohnkite](https://codeberg.org/anametologin/Krohnkite)
that is better maintained and more up-to-date and to avoid users running into outdated issues.

Thanks!